### PR TITLE
Fixed abstract to follow convention

### DIFF
--- a/lib/Kelp/Module/RDBO.pm
+++ b/lib/Kelp/Module/RDBO.pm
@@ -61,7 +61,7 @@ __END__
 
 =pod
 
-=head1 TITLE
+=head1 NAME
 
 Kelp::Module::RDBO - Kelp interface to Rose::DB::Object
 


### PR DESCRIPTION
Hi,

This changes the =head1 TITLE to =head1 NAME, which is the convention for defining the abstract.

As a result of this not having the expected NAME title, various tools don't find the abstract for your module. For example MetaCPAN doesn't display your module in the usual way, in search results.

Cheers,
Neil
